### PR TITLE
Error handling

### DIFF
--- a/check-mailgun.go
+++ b/check-mailgun.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/mackerelio/checkers"
@@ -16,7 +17,10 @@ var opts struct {
 }
 
 func mailgunEndPoint() string {
-	flags.Parse(&opts)
+	_, err := flags.Parse(&opts)
+	if err != nil {
+		os.Exit(1)
+	}
 	url := fmt.Sprintf("https://api.mailgun.net/v3/domains/%s", *opts.Domain)
 
 	return url

--- a/check-mailgun.go
+++ b/check-mailgun.go
@@ -67,6 +67,8 @@ func run() *checkers.Checker {
 	checkSt := checkers.OK
 	if st != "active" {
 		checkSt = checkers.CRITICAL
+		msg := fmt.Sprintf("%s is dead\n", *opts.Domain)
+		return checkers.NewChecker(checkSt, msg)
 	}
 
 	msg := fmt.Sprintf("%s is %s\n", *opts.Domain, st)


### PR DESCRIPTION
正常

```
$ go run check-mailgun.go -p key-xxxx -d ghost.ponpokopon.me
State OK: ghost.ponpokopon.me is active
```

必須オプション無しな場合

```
$ go run check-mailgun.go
the required flags `-d, --domain' and `-p, --apikey' were not specified
exit status 1
```

apiキーが無効な場合

```
$ go run check-mailgun.go -p key-hogehoge -d ghost.ponpokopon.me
State CRITICAL: ghost.ponpokopon.me is dead

exit status 2
```

ドメインが無効な場合

```
$ go run check-mailgun.go -p key-xxxx -d ghost.ponpokopon.hoge
State CRITICAL: ghost.ponpokopon.hoge is dead

exit status 2
```